### PR TITLE
chore: render go.mod content using text/template

### DIFF
--- a/cli/tests/a.expect
+++ b/cli/tests/a.expect
@@ -22,4 +22,3 @@ require (
 require (
 	example.com/g/h v1.3.0 // indirect
 )
-

--- a/e2e/fmt/exp.mod
+++ b/e2e/fmt/exp.mod
@@ -36,4 +36,3 @@ require (
 exclude (
 	github.com/shoenig/test v0.5.0
 )
-

--- a/modfile/go.mod.tmpl
+++ b/modfile/go.mod.tmpl
@@ -1,0 +1,71 @@
+module {{ .Module }}
+
+go {{ .Go }}
+
+{{- if .Toolchain.Version }}
+
+{{ if .Toolchain.Comment }}// {{ .Toolchain.Comment }}{{ end }}
+toolchain {{ .Toolchain.Version }}
+{{- end }}
+
+{{- if .Replace.Replacements }}
+{{ if .Replace.Comment }}
+// {{ .Replace.Comment }}
+{{- end }}
+replace (
+{{- range .Replace.Replacements }}
+{{ printf "\t" }}{{ . }}
+{{- end }}
+)
+{{- end }}
+
+{{- if .ReplaceSub.Replacements }}
+{{ if .ReplaceSub.Comment }}
+// {{ .ReplaceSub.Comment }}
+{{- end }}
+replace (
+{{- range .ReplaceSub.Replacements }}
+{{ printf "\t" }}{{ . }}
+{{- end }}
+)
+{{- end }}
+
+{{- if .Direct.Dependencies }}
+
+require (
+{{- range .Direct.Dependencies }}
+{{ printf "\t" }}{{ . }}
+{{- end }}
+)
+{{- end }}
+
+{{- if .Indirect.Dependencies }}
+
+require (
+{{- range .Indirect.Dependencies }}
+{{ printf "\t" }}{{ . }} // indirect
+{{- end }}
+)
+{{- end }}
+
+{{- if .Exclude.Dependencies }}
+{{ if .Exclude.Comment }}
+// {{ .Exclude.Comment }}
+{{- end }}
+exclude (
+{{- range .Exclude.Dependencies }}
+{{ printf "\t" }}{{ . }}
+{{- end }}
+)
+{{- end }}
+
+{{- if .Tool.Dependencies }}
+{{ if .Tool.Comment }}
+// {{ .Tool.Comment }}
+{{- end }}
+tool (
+{{- range .Tool.Dependencies }}
+{{ printf "\t" }}{{ . }}
+{{- end }}
+)
+{{- end }}

--- a/modfile/tests/comments.expect
+++ b/modfile/tests/comments.expect
@@ -6,4 +6,3 @@ require (
 	github.com/a/b v1.1.1
 	github.com/c/d v1.0.0
 )
-

--- a/modfile/tests/parens.expect
+++ b/modfile/tests/parens.expect
@@ -11,4 +11,3 @@ require (
 	example.com/b/a/v2 v2.0.0 // indirect
 	example.com/d/c v1.0.1 // indirect
 )
-

--- a/modfile/tests/replace.expect
+++ b/modfile/tests/replace.expect
@@ -16,4 +16,3 @@ require (
 	example.com/c/d/v2 v2.2.2
 	example.com/api v1.1.1
 )
-

--- a/modfile/tests/simple.expect
+++ b/modfile/tests/simple.expect
@@ -1,4 +1,3 @@
 module github.com/example/project
 
 go 1.21.0
-


### PR DESCRIPTION
Embed a template file which is utilized by the text/template package when contents are rendered out instead of sprintf calls.

Also fixes a bug where a double newline would be added to the end of some go.mod files, resulting in conflicts with other linters.

Resolves #4 